### PR TITLE
Added follow counts and list to profile

### DIFF
--- a/epoch_backend/business/api_endpoints/following_endpoints.py
+++ b/epoch_backend/business/api_endpoints/following_endpoints.py
@@ -13,15 +13,35 @@ def get_account_list(session_id, session_persistence, user_persistence):
         return ([500, "Could not retrieve user list", b"<h1>500 Internal Server Error</h1>"])
 
 
-def get_following_list(session_id, session_persistence, user_persistence):
+def get_following_list(session_id, session_persistence, user_persistence, target):
     try:
         user_id_l = session_persistence.get_user_by_session_id(session_id)
         user_id = [int(l[0]) for l in user_id_l][0] #convert what is returned to an int
     except:
         return ([500, "No valid session", b"<h1>500 Internal Server Error</h1>"])
+    
+    if target != "self":
+        user_id = int(target)
+
     try:
         followingList = user_persistence.get_following(user_id)
         return ([200, "OK", followingList.encode('UTF-8')])
+    except:
+        return ([500, "Could not retrieve following list", b"<h1>500 Internal Server Error</h1>"])
+    
+def get_follower_list(session_id, session_persistence, user_persistence, target):
+    try:
+        user_id_l = session_persistence.get_user_by_session_id(session_id)
+        user_id = [int(l[0]) for l in user_id_l][0] #convert what is returned to an int
+    except:
+        return ([500, "No valid session", b"<h1>500 Internal Server Error</h1>"])
+    
+    if target != "self":
+        user_id = int(target)
+
+    try:
+        followerList = user_persistence.get_followers(user_id)
+        return ([200, "OK", followerList.encode('UTF-8')])
     except:
         return ([500, "Could not retrieve following list", b"<h1>500 Internal Server Error</h1>"])
 

--- a/epoch_backend/business/api_endpoints/router.py
+++ b/epoch_backend/business/api_endpoints/router.py
@@ -1,7 +1,7 @@
 import json
 import os
 
-from ..api_endpoints.following_endpoints import follow_user, get_account_list, get_following_list, unfollow_user
+from ..api_endpoints.following_endpoints import follow_user, get_account_list, get_follower_list, get_following_list, unfollow_user
 from ..utils import get_cors_headers, get_origin_from_headers, send_response, get_last_modified, guess_file_type, get_session_id_from_request, send_cors_options_response
 from ..api_endpoints.user_endpoints import delete_by_user_id, delete_by_username, post_user, get_user, register_user, get_user_from_name, upload_profile_pic, update_user_info
 from ..db_controller.access_user_persistence import access_user_persistence
@@ -109,14 +109,27 @@ def handle_api_request(method, path, request_data, conn):
         # handle specific request
         if path == "/api/follow/accountList/" and method == 'GET':
             response = get_account_list(session_id, access_session_persistence(), access_user_persistence())
+
         elif path == "/api/follow/followingList/" and method == 'GET':
-            response = get_following_list(session_id, access_session_persistence(), access_user_persistence())
+            response = get_following_list(session_id, access_session_persistence(), access_user_persistence(), "self")
+
+        elif path == "/api/follow/followingList/" and method == 'POST':
+            if content_length>0:
+                target = data["target"]
+            response = get_following_list(session_id, access_session_persistence(), access_user_persistence(), target)
+
+        elif path == "/api/follow/followerList/" and method == 'POST':
+            if content_length>0:
+                target = data["target"]
+            response = get_follower_list(session_id, access_session_persistence(), access_user_persistence(), target)
+
         elif path == "/api/follow/follow/" and method == 'POST':
             if content_length>0:
                 toFollow = data["userToFollow"]
                 response = follow_user(session_id, toFollow, access_session_persistence(), access_user_persistence())
             else:
                 response = [500, "Server error: no request body",b"<h1>500 Internal Server Error</h1>"]
+
         elif path == "/api/follow/unfollow/" and method == 'POST':
             if content_length>0:
                 toUnfollow = data["userToUnfollow"]

--- a/epoch_backend/persistence/epoch/epoch_user_persistence.py
+++ b/epoch_backend/persistence/epoch/epoch_user_persistence.py
@@ -156,8 +156,10 @@ class epoch_user_persistence(user_persistence):
         cursor.close()
         connection.close()
         rowHeaders = [name[0] for name in cursor.description]
+        rowHeaders.append("username")
         json_data = []
         for value in result:
+            value = value + (self.get_username(int(value[0]))[0][0],)
             json_data.append(dict(zip(rowHeaders, value)))
         return json.dumps(json_data)
     
@@ -174,7 +176,7 @@ class epoch_user_persistence(user_persistence):
         rowHeaders.append("username")
         json_data = []
         for value in result:
-            value = value + ("loading...",) # adding placeholder for following username since following usernames are added to this object client side
+            value = value + (self.get_username(int(value[0]))[0][0],)
             json_data.append(dict(zip(rowHeaders, value)))
         return json.dumps(json_data)
     

--- a/epoch_backend/tests/following_unit_tests.py
+++ b/epoch_backend/tests/following_unit_tests.py
@@ -64,18 +64,18 @@ class following_unit_tests(unittest.TestCase):
         assert response[2] != None
 
     def test_3_following_list_valid_id(self):
-        response = get_following_list("valid_id", MockSessionPersistence(), MockUserPersistence())
+        response = get_following_list("valid_id", MockSessionPersistence(), MockUserPersistence(), "self")
         print(response)
         assert response[0] == 200
         assert response[2] != None
     def test_4_following_list_invalid_id(self):
-        response = get_following_list("invalid_id", MockSessionPersistence(), MockUserPersistence())
+        response = get_following_list("invalid_id", MockSessionPersistence(), MockUserPersistence(), "self")
         print(response)
         assert response[0] == 500
         assert response[1] == "Could not retrieve following list"
         assert response[2] != None
     def test_5_following_list_invalid_data(self):
-        response = get_following_list("something_wrong", MockSessionPersistence(), MockUserPersistence())
+        response = get_following_list("something_wrong", MockSessionPersistence(), MockUserPersistence(), "self")
         print(response)
         assert response[0] == 500
         assert response[1] == "No valid session"

--- a/epoch_frontend/src/pages/profile.js
+++ b/epoch_frontend/src/pages/profile.js
@@ -33,8 +33,8 @@ function Profile() {
     const [showOverlay, setShowOverlay] = useState(false);
     const [overlayImageUrl, setOverlayImageUrl] = useState('');
 
-    const[followerCount, setFollowerCount] = useState(0);
-    const[followingCount, setFollowingCount] = useState(0);
+    const[followerCount, setFollowerCount] = useState("....");
+    const[followingCount, setFollowingCount] = useState("....");
     const[followerList, setFollowerList] = useState({});
     const[followingList, setFollowingList] = useState({});
 
@@ -43,11 +43,14 @@ function Profile() {
             unfollowAccount(target);
             setIsFollowingPrompt('Follow');
             setIsFollowing(false);
+            setFollowerCount(followerCount - 1);
         } else {
             followAccount(target);
             setIsFollowingPrompt('Unfollow');
             setIsFollowing(true);
+            setFollowerCount(followerCount + 1);
         }
+        setIsCurrentUser(false);
     }
 
     const handleProfilePhotoClick = (imageUrl) => {

--- a/epoch_frontend/src/pages/userlist.js
+++ b/epoch_frontend/src/pages/userlist.js
@@ -104,7 +104,6 @@ function Userlist() {
             }
             setFilteredList(tempFiltered);
         }
-        console.log(filteredList);
         changeStatus(!changedStatus);
     },[searchInput, changedStatus, filteredList, userList]);
 

--- a/epoch_frontend/src/styles/Profile.css
+++ b/epoch_frontend/src/styles/Profile.css
@@ -8,7 +8,24 @@
     width: 50%;
 }
 
+.counts-wrapper{
+    display: table;
+    margin: auto;
+    justify-content: center;
+    
+}
 
+.follower-count{
+    padding: 1rem;
+    display: table-cell;
+    cursor: pointer;
+}
+
+.following-count{
+    padding: 1rem;
+    display: table-cell;
+    cursor: pointer;
+}
 
 .profile-info-wrapper {
     text-align: center;
@@ -24,6 +41,7 @@
 }
 
 .profile-pic {
+    cursor: pointer;
     position: relative;
     width: 10rem;
     height: 10rem;
@@ -36,6 +54,7 @@
 }
 
 .background-pic {
+    cursor: pointer;
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
- added follower and following counts to profile page
- on click will show list of all either follower accounts or following accounts
- added ability to get followers for an account id
- slightly changed following api to allow for feature
- - getFollowing/FollowerList is now either getting for self or for some id
- db queries for getFollowing/FollowerList now also return usernames
- fixed errors in unit tests caused by changes